### PR TITLE
Id site

### DIFF
--- a/lib/stormpath-sdk.rb
+++ b/lib/stormpath-sdk.rb
@@ -22,6 +22,7 @@ module Stormpath
   autoload :ApiKey, 'stormpath-sdk/api_key'
   autoload :Client, 'stormpath-sdk/client'
   autoload :DataStore, 'stormpath-sdk/data_store'
+  autoload :IdSiteResult, 'stormpath-sdk/id_site_result'
 
   module Resource
     autoload :Expansion, 'stormpath-sdk/resource/expansion'

--- a/lib/stormpath-sdk.rb
+++ b/lib/stormpath-sdk.rb
@@ -5,6 +5,7 @@ require "openssl"
 require "open-uri"
 require "uri"
 require "uuidtools"
+require "jwt"
 require "yaml"
 require 'active_support'
 require "active_support/core_ext"

--- a/lib/stormpath-sdk/client.rb
+++ b/lib/stormpath-sdk/client.rb
@@ -31,8 +31,8 @@ module Stormpath
       assert_not_nil @api_key, "No API key has been provided. Please pass an 'api_key' or " +
                               "'api_key_file_location' to the Stormpath::Client constructor."
 
-      request_executor = Stormpath::Http::HttpClientRequestExecutor.new(@api_key, proxy: options[:proxy])
-      @data_store = Stormpath::DataStore.new(request_executor, cache_opts, self, base_url)
+      request_executor = Stormpath::Http::HttpClientRequestExecutor.new(proxy: options[:proxy])
+      @data_store = Stormpath::DataStore.new(request_executor, @api_key, cache_opts, self, base_url)
     end
 
     def tenant(expansion = nil)

--- a/lib/stormpath-sdk/client.rb
+++ b/lib/stormpath-sdk/client.rb
@@ -20,18 +20,18 @@ module Stormpath
     include Stormpath::Util::Assert
     include Stormpath::Resource::Associations
 
-    attr_reader :data_store, :application
+    attr_reader :data_store, :application, :api_key
 
     def initialize(options)
       base_url = options[:base_url]
       cache_opts = options[:cache] || {}
 
-      api_key = ApiKey(options)
+      @api_key = ApiKey(options)
 
-      assert_not_nil api_key, "No API key has been provided. Please pass an 'api_key' or " +
+      assert_not_nil @api_key, "No API key has been provided. Please pass an 'api_key' or " +
                               "'api_key_file_location' to the Stormpath::Client constructor."
 
-      request_executor = Stormpath::Http::HttpClientRequestExecutor.new(api_key, proxy: options[:proxy])
+      request_executor = Stormpath::Http::HttpClientRequestExecutor.new(@api_key, proxy: options[:proxy])
       @data_store = Stormpath::DataStore.new(request_executor, cache_opts, self, base_url)
     end
 

--- a/lib/stormpath-sdk/client.rb
+++ b/lib/stormpath-sdk/client.rb
@@ -20,19 +20,19 @@ module Stormpath
     include Stormpath::Util::Assert
     include Stormpath::Resource::Associations
 
-    attr_reader :data_store, :application, :api_key
+    attr_reader :data_store, :application
 
     def initialize(options)
       base_url = options[:base_url]
       cache_opts = options[:cache] || {}
 
-      @api_key = ApiKey(options)
+      api_key = ApiKey(options)
 
-      assert_not_nil @api_key, "No API key has been provided. Please pass an 'api_key' or " +
+      assert_not_nil api_key, "No API key has been provided. Please pass an 'api_key' or " +
                               "'api_key_file_location' to the Stormpath::Client constructor."
 
       request_executor = Stormpath::Http::HttpClientRequestExecutor.new(proxy: options[:proxy])
-      @data_store = Stormpath::DataStore.new(request_executor, @api_key, cache_opts, self, base_url)
+      @data_store = Stormpath::DataStore.new(request_executor, api_key, cache_opts, self, base_url)
     end
 
     def tenant(expansion = nil)

--- a/lib/stormpath-sdk/data_store.rb
+++ b/lib/stormpath-sdk/data_store.rb
@@ -119,9 +119,9 @@ class Stormpath::DataStore
                MultiJson.dump(to_hash(resource))
              end
 
-      request = Request.new(http_method, href, query, Hash.new, body)
+      request = Request.new(http_method, href, query, Hash.new, body, @api_key)
       apply_default_request_headers request
-      response = @request_executor.execute_request request, @api_key
+      response = @request_executor.execute_request request
 
       result = response.body.length > 0 ? MultiJson.load(response.body) : ''
 

--- a/lib/stormpath-sdk/data_store.rb
+++ b/lib/stormpath-sdk/data_store.rb
@@ -24,14 +24,15 @@ class Stormpath::DataStore
 
   CACHE_REGIONS = %w(applications directories accounts groups groupMemberships accountMemberships tenants customData provider providerData)
 
-  attr_reader :client, :request_executor, :cache_manager
+  attr_reader :client, :request_executor, :cache_manager, :api_key, :base_url
 
-  def initialize(request_executor, cache_opts, client, base_url = nil)
+  def initialize(request_executor, api_key, cache_opts, client, base_url = nil)
     assert_not_nil request_executor, "RequestExecutor cannot be null."
 
     @client = client
     @base_url = base_url || DEFAULT_BASE_URL
     @request_executor = request_executor
+    @api_key = api_key
     initialize_cache cache_opts
   end
 
@@ -120,7 +121,7 @@ class Stormpath::DataStore
 
       request = Request.new(http_method, href, query, Hash.new, body)
       apply_default_request_headers request
-      response = @request_executor.execute_request request
+      response = @request_executor.execute_request request, @api_key
 
       result = response.body.length > 0 ? MultiJson.load(response.body) : ''
 

--- a/lib/stormpath-sdk/http/authc/sauthc1_signer.rb
+++ b/lib/stormpath-sdk/http/authc/sauthc1_signer.rb
@@ -40,7 +40,7 @@ module Stormpath
           @uuid_generator = uuid_generator
         end
 
-        def sign_request request, api_key
+        def sign_request request
           request.http_headers.delete(Sauthc1Signer::AUTHORIZATION_HEADER)
           request.http_headers.delete(Sauthc1Signer::STORMPATH_DATE_HEADER)
 
@@ -78,14 +78,14 @@ module Stormpath
                                signed_headers_string,
                                request_payload_hash_hex].join(NL)
 
-          id = [api_key.id, date_stamp, nonce, ID_TERMINATOR].join("/")
+          id = [request.api_key.id, date_stamp, nonce, ID_TERMINATOR].join("/")
 
           canonical_request_hash_hex = to_hex(hash_text(canonical_request))
 
           string_to_sign = [ALGORITHM, time_stamp, id, canonical_request_hash_hex].join(NL)
 
           # SAuthc1 uses a series of derived keys, formed by hashing different pieces of data
-          k_secret = to_utf8 AUTHENTICATION_SCHEME + api_key.secret
+          k_secret = to_utf8 AUTHENTICATION_SCHEME + request.api_key.secret
           k_date = sign date_stamp, k_secret, DEFAULT_ALGORITHM
           k_nonce = sign nonce, k_date, DEFAULT_ALGORITHM
           k_signing = sign ID_TERMINATOR, k_nonce, DEFAULT_ALGORITHM

--- a/lib/stormpath-sdk/http/http_client_request_executor.rb
+++ b/lib/stormpath-sdk/http/http_client_request_executor.rb
@@ -19,18 +19,17 @@ module Stormpath
       include Stormpath::Http::Authc
       include Stormpath::Util::Assert
 
-      def initialize(api_key, options = {})
+      def initialize(options = {})
         @signer = Sauthc1Signer.new
-        @api_key = api_key
         @http_client = HTTPClient.new options[:proxy]
       end
 
-      def execute_request(request, redirects_limit = 10)
+      def execute_request(request, api_key, redirects_limit = 10)
         assert_not_nil request, "Request argument cannot be null."
 
         @redirect_response = nil
 
-        @signer.sign_request request, @api_key
+        @signer.sign_request request, api_key
 
         domain = if request.query_string.present?
                    [request.href, request.to_s_query_string(true)].join '?'
@@ -45,7 +44,7 @@ module Stormpath
         if response.redirect? and redirects_limit > 0
           request.href = response.http_header['location'][0]
           redirects_limit -= 1
-          @redirect_response = execute_request request, redirects_limit
+          @redirect_response = execute_request request, api_key, redirects_limit
           return @redirect_response
         end
 

--- a/lib/stormpath-sdk/http/http_client_request_executor.rb
+++ b/lib/stormpath-sdk/http/http_client_request_executor.rb
@@ -24,12 +24,12 @@ module Stormpath
         @http_client = HTTPClient.new options[:proxy]
       end
 
-      def execute_request(request, api_key, redirects_limit = 10)
+      def execute_request(request, redirects_limit = 10)
         assert_not_nil request, "Request argument cannot be null."
 
         @redirect_response = nil
 
-        @signer.sign_request request, api_key
+        @signer.sign_request request
 
         domain = if request.query_string.present?
                    [request.href, request.to_s_query_string(true)].join '?'
@@ -44,7 +44,7 @@ module Stormpath
         if response.redirect? and redirects_limit > 0
           request.href = response.http_header['location'][0]
           redirects_limit -= 1
-          @redirect_response = execute_request request, api_key, redirects_limit
+          @redirect_response = execute_request request, redirects_limit
           return @redirect_response
         end
 

--- a/lib/stormpath-sdk/http/request.rb
+++ b/lib/stormpath-sdk/http/request.rb
@@ -18,9 +18,9 @@ module Stormpath
     class Request
       include Stormpath::Http::Utils
 
-      attr_accessor :http_method, :href, :query_string, :http_headers, :body
+      attr_accessor :http_method, :href, :query_string, :http_headers, :body, :api_key
 
-      def initialize(http_method, href, query_string, http_headers, body)
+      def initialize(http_method, href, query_string, http_headers, body, api_key)
 
         splitted = href.split '?'
 
@@ -41,6 +41,7 @@ module Stormpath
         @http_method = http_method.upcase
         @http_headers = http_headers
         @body = body
+        @api_key = api_key
 
         if body
           @http_headers.store 'Content-Length', @body.bytesize

--- a/lib/stormpath-sdk/id_site_result.rb
+++ b/lib/stormpath-sdk/id_site_result.rb
@@ -1,0 +1,17 @@
+module Stormpath
+  class IdSiteResult
+    attr_accessor :account, :state, :status
+
+    def initialize(jwt_response)
+      @account = jwt_response["sub"]
+      @status = jwt_response["status"]
+      @state = jwt_response["state"]
+      @is_new_account = jwt_response["isNewSub"]
+    end
+
+    def new_account?
+      @is_new_account
+    end
+  end
+end
+

--- a/lib/stormpath-sdk/id_site_result.rb
+++ b/lib/stormpath-sdk/id_site_result.rb
@@ -2,7 +2,6 @@ module Stormpath
   class IdSiteResult
     attr_accessor :account_href, :state, :status, :is_new_account
 
-    alias_method :is_new_account?, :is_new_account
     alias_method :new_account?, :is_new_account
 
     def initialize(jwt_response)

--- a/lib/stormpath-sdk/id_site_result.rb
+++ b/lib/stormpath-sdk/id_site_result.rb
@@ -1,16 +1,15 @@
 module Stormpath
   class IdSiteResult
-    attr_accessor :account, :state, :status
+    attr_accessor :account_href, :state, :status, :is_new_account
+
+    alias_method :is_new_account?, :is_new_account
+    alias_method :new_account?, :is_new_account
 
     def initialize(jwt_response)
-      @account = jwt_response["sub"]
+      @account_href = jwt_response["sub"]
       @status = jwt_response["status"]
       @state = jwt_response["state"]
       @is_new_account = jwt_response["isNewSub"]
-    end
-
-    def new_account?
-      @is_new_account
     end
   end
 end

--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -15,6 +15,7 @@
 #
 class Stormpath::Resource::Application < Stormpath::Resource::Instance
   include Stormpath::Resource::Status
+  include UUIDTools
 
   class LoadError < Stormpath::Error; end
 

--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -72,9 +72,9 @@ class Stormpath::Resource::Application < Stormpath::Resource::Instance
     params = CGI::parse(uri.query)
     token = params["jwtResponse"].first
 
-    jwt_response, _header = JWT.decode(token, client.api_key.secret)
+    jwt_response, _header = JWT.decode(token, client.data_store.api_key.secret)
 
-    raise Stormpath::Error.new if jwt_response["aud"] != client.api_key.id
+    raise Stormpath::Error.new if jwt_response["aud"] != client.data_store.api_key.id
 
     Stormpath::IdSiteResult.new(jwt_response)
   end

--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -72,12 +72,7 @@ class Stormpath::Resource::Application < Stormpath::Resource::Instance
     params = CGI::parse(uri.query)
     token = params["jwtResponse"].first
 
-    begin
-      jwt_response = JWT.decode(token, client.api_key.secret)
-      jwt_response = jwt_response.first if jwt_response.kind_of?(Array)
-    rescue JWT::DecodeError, JWT::ExpiredSignature => e
-      raise e
-    end
+    jwt_response, _header = JWT.decode(token, client.api_key.secret)
 
     raise Stormpath::Error.new if jwt_response["aud"] != client.api_key.id
 

--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -49,7 +49,7 @@ class Stormpath::Resource::Application < Stormpath::Resource::Instance
   end
 
   def create_id_site_url(options = {})
-    base = "https://" + DEFAULT_SERVER_HOST + "/sso"
+    base = client.data_store.base_url.sub("v" + Stormpath::DataStore::DEFAULT_API_VERSION.to_s, "sso")
     base += '/logout' if options[:logout]
 
     token = JWT.encode({

--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -55,12 +55,12 @@ class Stormpath::Resource::Application < Stormpath::Resource::Instance
     token = JWT.encode({
         'iat' => Time.now.to_i,
         'jti' => UUID.method(:random_create).call.to_s,
-        'iss' => client.api_key.id,
+        'iss' => client.data_store.api_key.id,
         'sub' => href,
         'cb_uri' => options[:callback_uri],
         'path' => options[:path] || '',
         'state' => options[:state] || ''
-      }, client.api_key.secret, 'HS256')
+      }, client.data_store.api_key.secret, 'HS256')
 
     base + '?jwtRequest=' + token
   end

--- a/spec/auth/basic_authenticator_spec.rb
+++ b/spec/auth/basic_authenticator_spec.rb
@@ -4,7 +4,7 @@ describe "BasicAuthenticator" do
   context "given an instance of BasicAuthenticator" do
 
     before do
-      data_store = Stormpath::DataStore.new "", {}, ""
+      data_store = Stormpath::DataStore.new "", "", {}, ""
       allow(test_api_client).to receive(:data_store).and_return(data_store)
       auth_result = Stormpath::Authentication::AuthenticationResult.new({}, test_api_client)
       allow(data_store).to receive(:create).and_return(auth_result)

--- a/spec/auth/sauthc1_signer_spec.rb
+++ b/spec/auth/sauthc1_signer_spec.rb
@@ -19,17 +19,17 @@ describe Stormpath::Http::Authc::Sauthc1Signer do
         let(:fake_api_key) { Stormpath::ApiKey.new('foo', 'bar') }
 
         let(:empty_query_hash_request) do
-          Stormpath::Http::Request.new 'get', 'http://example.com/resources/abc123?q=red blue', nil, Hash.new, nil
+          Stormpath::Http::Request.new 'get', 'http://example.com/resources/abc123?q=red blue', nil, Hash.new, nil, test_api_key
         end
 
         let(:filled_query_hash_request) do
-          Stormpath::Http::Request.new 'get', 'http://example.com/resources/abc123', {'q' => 'red blue'}, Hash.new, nil
+          Stormpath::Http::Request.new 'get', 'http://example.com/resources/abc123', {'q' => 'red blue'}, Hash.new, nil, test_api_key
         end
 
         before do
           Timecop.freeze(Time.now)
-          signer.sign_request empty_query_hash_request, fake_api_key
-          signer.sign_request filled_query_hash_request, fake_api_key
+          signer.sign_request empty_query_hash_request
+          signer.sign_request filled_query_hash_request
         end
 
         it 'assigns identical headers to both requests' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -262,7 +262,7 @@ properties
       it 'initializes the request executor with the proxy' do
         expect(Stormpath::Http::HttpClientRequestExecutor)
           .to receive(:new)
-          .with(api_key, proxy: http_proxy)
+          .with(proxy: http_proxy)
           .and_return request_executor
 
         Stormpath::Client.new api_key: api_key, proxy: http_proxy

--- a/spec/data_store_spec.rb
+++ b/spec/data_store_spec.rb
@@ -4,7 +4,7 @@ describe Stormpath::DataStore do
   let(:factory)           { Stormpath::Test::ResourceFactory.new }
   let(:request_executor)  { Stormpath::Test::TestRequestExecutor.new }
   let(:store)             { Stormpath::Cache::RedisStore }
-  let(:data_store)        { Stormpath::DataStore.new request_executor, {store: store}, nil, nil }
+  let(:data_store)        { Stormpath::DataStore.new request_executor, test_api_key, {store: store}, nil, nil }
   let(:application_cache) { data_store.cache_manager.get_cache 'applications' }
   let(:tenant_cache)      { data_store.cache_manager.get_cache 'tenants' }
   let(:group_cache)       { data_store.cache_manager.get_cache 'groups' }

--- a/spec/provider/account_resolver_spec.rb
+++ b/spec/provider/account_resolver_spec.rb
@@ -4,7 +4,7 @@ describe "ProviderAccountResolver" do
   context "given an instance of ProviderAccountResolver" do
 
     before do
-      data_store = Stormpath::DataStore.new "", {}, ""
+      data_store = Stormpath::DataStore.new "", "", {}, ""
       allow(test_api_client).to receive(:data_store).and_return(data_store)
       auth_result = Stormpath::Provider::AccountResult.new({}, test_api_client)
       allow(data_store).to receive(:create).and_return(auth_result)

--- a/spec/resource/application_spec.rb
+++ b/spec/resource/application_spec.rb
@@ -360,7 +360,7 @@ describe Stormpath::Resource::Application, :vcr do
       end
 
       it 'should set the correct account on IdSiteResult object' do
-        expect(@site_result.account).to eq(application.href)
+        expect(@site_result.account_href).to eq(application.href)
       end
 
       it 'should set the correct status on IdSiteResult object' do

--- a/spec/resource/application_spec.rb
+++ b/spec/resource/application_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include UUIDTools
 
 describe Stormpath::Resource::Application, :vcr do
   let(:app) { test_api_client.applications.create name: random_application_name, description: 'Dummy desc.' }
@@ -325,6 +326,131 @@ describe Stormpath::Resource::Application, :vcr do
 
     context 'with logout option' do
       it 'shoud create a request to /sso/logout' do
+      end
+    end
+  end
+
+  describe '#handle_id_site_callback' do
+    let(:callback_uri_base) { 'http://localhost:9292/somwhere?jwtResponse=' }
+
+    context 'without the response_url provided' do
+      it 'should raise argument error' do
+        expect { application.handle_id_site_callback(nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with a valid jwt response' do
+      let(:jwt_token) { JWT.encode({
+          'iat' => Time.now.to_i,
+          'aud' => test_api_key_id,
+          'sub' => application.href,
+          'path' => '',
+          'state' => '',
+          'isNewSub' => true,
+          'status' => "REGISTERED"
+        }, test_api_key_secret, 'HS256')
+      }
+
+      before do
+        @site_result = application.handle_id_site_callback(callback_uri_base + jwt_token)
+      end
+
+      it 'should return IdSiteResult object' do
+        expect(@site_result).to be_kind_of(Stormpath::IdSiteResult)
+      end
+
+      it 'should set the correct account on IdSiteResult object' do
+        expect(@site_result.account).to eq(application.href)
+      end
+
+      it 'should set the correct status on IdSiteResult object' do
+        expect(@site_result.status).to eq("REGISTERED")
+      end
+
+      it 'should set the correct state on IdSiteResult object' do
+        expect(@site_result.state).to eq("")
+      end
+
+      it 'should set the correct is_new_account on IdSiteResult object' do
+        expect(@site_result.new_account?).to eq(true)
+      end
+    end
+
+    context 'with an expired token' do
+      let(:jwt_token) { JWT.encode({
+          'iat' => Time.now.to_i,
+          'aud' => test_api_key_id,
+          'sub' => application.href,
+          'path' => '',
+          'state' => '',
+          'exp' => Time.now.to_i - 1,
+          'isNewSub' => true,
+          'status' => "REGISTERED"
+        }, test_api_key_secret, 'HS256')
+      }
+
+      it 'should raise expiration error' do
+        expect {
+          application.handle_id_site_callback(callback_uri_base + jwt_token)
+        }.to raise_error(JWT::DecodeError)
+      end
+    end
+
+    context 'with a different client id (aud)' do
+      let(:jwt_token) { JWT.encode({
+          'iat' => Time.now.to_i,
+          'aud' => UUID.method(:random_create).call.to_s,
+          'sub' => application.href,
+          'path' => '',
+          'state' => '',
+          'isNewSub' => true,
+          'status' => "REGISTERED"
+        }, test_api_key_secret, 'HS256')
+      }
+
+      it 'should raise error' do
+        expect {
+          application.handle_id_site_callback(callback_uri_base + jwt_token)
+        }.to raise_error(Stormpath::Error)
+      end
+    end
+
+    context 'with an invalid exp value' do
+      let(:jwt_token) { JWT.encode({
+          'iat' => Time.now.to_i,
+          'aud' => test_api_key_id,
+          'sub' => application.href,
+          'path' => '',
+          'state' => '',
+          'exp' => 'not gona work',
+          'isNewSub' => true,
+          'status' => "REGISTERED"
+        }, test_api_key_secret, 'HS256')
+      }
+
+      it 'should error with the expiration error' do
+        expect {
+          application.handle_id_site_callback(callback_uri_base + jwt_token)
+        }.to raise_error(JWT::DecodeError)
+      end
+    end
+
+    context 'with an invalid signature' do
+      let(:jwt_token) { JWT.encode({
+          'iat' => Time.now.to_i,
+          'aud' => test_api_key_id,
+          'sub' => application.href,
+          'path' => '',
+          'state' => '',
+          'isNewSub' => true,
+          'status' => "REGISTERED"
+        }, 'false key', 'HS256')
+      }
+
+      it 'should reject the signature' do
+        expect {
+          application.handle_id_site_callback(callback_uri_base + jwt_token)
+        }.to raise_error(JWT::DecodeError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'stormpath-sdk'
 require 'pry'
 require 'webmock/rspec'
 require 'vcr'
+require 'jwt'
 
 Dir['./spec/support/*.rb'].each { |file| require file }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'pry'
 require 'webmock/rspec'
 require 'vcr'
 require 'jwt'
+require 'uuidtools'
 
 Dir['./spec/support/*.rb'].each { |file| require file }
 

--- a/spec/support/test_request_executor.rb
+++ b/spec/support/test_request_executor.rb
@@ -3,7 +3,7 @@ module Stormpath
     class TestRequestExecutor
       attr_writer :response
 
-      def execute_request(request, api_key)
+      def execute_request(request)
         Stormpath::Http::Response.new 200, 'text/json', @response, @response.length
       end
     end

--- a/spec/support/test_request_executor.rb
+++ b/spec/support/test_request_executor.rb
@@ -3,7 +3,7 @@ module Stormpath
     class TestRequestExecutor
       attr_writer :response
 
-      def execute_request(request)
+      def execute_request(request, api_key)
         Stormpath::Http::Response.new 200, 'text/json', @response, @response.length
       end
     end

--- a/stormpath-sdk.gemspec
+++ b/stormpath-sdk.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.8')
   s.add_dependency('properties-ruby', "~> 0.0.4")
   s.add_dependency('java_properties')
+  s.add_dependency('jwt')
 
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rspec', '~> 3.0.0'

--- a/stormpath-sdk.gemspec
+++ b/stormpath-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.8')
   s.add_dependency('properties-ruby', "~> 0.0.4")
   s.add_dependency('java_properties')
-  s.add_dependency('jwt')
+  s.add_dependency('jwt', '>= 1.5.0')
 
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rspec', '~> 3.0.0'


### PR DESCRIPTION
Hi,

I’ve implemented the ID Site feature http://docs.stormpath.com/guides/using-id-site/

Two methods where added to the application class, create_id_site_url and and handle_id_site_callback which handle the creation of url with JWT token required for ID Site and callback request which is returned. If everything went ok the IdSiteResult object is returned which contains sub, status, state and isNewSub information. From the documentation http://docs.stormpath.com/guides/using-id-site/#handling-the-callback-to-your-application-from-id-site and other libraries my assumption was that these four fields are sufficient data on return.  The SDK API functions similar to Python sdk. I tested it with my sinatra app with storm path implementation and everything works fine.

url = application.create_id_site_url callback_uri: "http://darksidecentral.com/id-site-sso"
url = application.create_id_site_url( callback_uri: “http://darksidecentral.com/id-site-callback", logout: true )

result = application.handle_id_site_callback url_response

Regarding the failing tests. They fail because of the encryption keys http://docs.travis-ci.com/user/encryption-keys/ Also more info can be found here http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests  "Please note that encrypted environment variables are not available for pull requests from forks.” When runned localy the tests are passing.

Please let me know if you have any suggestions or if something else needs to be added to the implementation. 

Regards,
Nenad
