### PR TITLE
Client credentials oauth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
 - 2.1.5
-- 2.2.4
-- 2.3.0
+- 2.3.1
 services:
 - redis-server
 before_install:

--- a/README.md
+++ b/README.md
@@ -390,6 +390,30 @@ grant_request = Stormpath::Oauth::IdSiteGrantRequest.new jwt_token
 response = application.authenticate_oauth grant_request
 ```
 
+### Exchange Client Credentials for a Stormpath Access Token
+
+As a developer, I want to authenticate API Keys directly against my application endpoint, so that I can have Stormpath generate an application token that I can use for a session.
+
+Create an API Key for an account:
+
+```ruby
+account_api_key = account.api_keys.create({})
+```
+
+Then create an client credentials request and get a authentication result:
+
+```ruby
+client_credentials_grant_request = Stormpath::Oauth::ClientCredentialsGrantRequest.new(
+  account_api_key.id,
+  account_api_key.secret
+)
+
+authentication_result = application.authenticate_oauth(client_credentials_grant_request)
+
+puts authentication_result.access_token
+puts authentication_result.refresh_token
+```
+
 ### Registering Accounts
 
 Accounts are created on a directory instance. They can be created in two

--- a/lib/stormpath-sdk.rb
+++ b/lib/stormpath-sdk.rb
@@ -128,5 +128,7 @@ module Stormpath
     autoload :Error, 'stormpath-sdk/oauth/error'
     autoload :IdSiteGrantRequest, "stormpath-sdk/oauth/id_site_grant_request"
     autoload :IdSiteGrant, "stormpath-sdk/oauth/id_site_grant"
+    autoload :ClientCredentialsGrantRequest, "stormpath-sdk/oauth/client_credentials_grant_request"
+    autoload :ClientCredentialsGrant, "stormpath-sdk/oauth/client_credentials_grant"
   end
 end

--- a/lib/stormpath-sdk/data_store.rb
+++ b/lib/stormpath-sdk/data_store.rb
@@ -284,18 +284,7 @@ class Stormpath::DataStore
     end
 
     def form_request_parse(resource)
-      data = ""
-
-      property_names = resource.get_dirty_property_names
-      property_names.each do |name|
-        if name != "formData"
-          property = resource.get_property name, ignore_camelcasing: true
-          data += name.underscore + '=' + property.to_s
-          data += '&' unless name == property_names.last
-        end
-      end
-
-      data
+      URI.encode_www_form(resource.form_properties.to_a)
     end
 
     def to_hash(resource)

--- a/lib/stormpath-sdk/oauth/authenticator.rb
+++ b/lib/stormpath-sdk/oauth/authenticator.rb
@@ -22,7 +22,8 @@ module Stormpath
         password: PasswordGrant,
         refresh_token: RefreshToken,
         id_site_token: IdSiteGrant,
-        stormpath_token: StormpathTokenGrant
+        stormpath_token: StormpathTokenGrant,
+        client_credentials: ClientCredentialsGrant
       }.freeze
     end
   end

--- a/lib/stormpath-sdk/oauth/client_credentials_grant.rb
+++ b/lib/stormpath-sdk/oauth/client_credentials_grant.rb
@@ -1,0 +1,25 @@
+module Stormpath
+  module Oauth
+    class ClientCredentialsGrant < Stormpath::Resource::Base
+      prop_accessor :grant_type, :api_key_id, :api_key_secret
+
+      def form_properties
+        {
+          grant_type: grant_type,
+          apiKeyId: api_key_id,
+          apiKeySecret: api_key_secret
+        }
+      end
+
+      def set_options(request)
+        set_property :api_key_id, request.api_key_id
+        set_property :api_key_secret, request.api_key_secret
+        set_property :grant_type, request.grant_type
+      end
+
+      def form_data?
+        true
+      end
+    end
+  end
+end

--- a/lib/stormpath-sdk/oauth/client_credentials_grant_request.rb
+++ b/lib/stormpath-sdk/oauth/client_credentials_grant_request.rb
@@ -1,0 +1,16 @@
+module Stormpath
+  module Oauth
+    class ClientCredentialsGrantRequest
+      attr_reader :api_key_id, :api_key_secret
+
+      def initialize(api_key_id, api_key_secret)
+        @api_key_id = api_key_id
+        @api_key_secret = api_key_secret
+      end
+
+      def grant_type
+        'client_credentials'
+      end
+    end
+  end
+end

--- a/lib/stormpath-sdk/oauth/id_site_grant.rb
+++ b/lib/stormpath-sdk/oauth/id_site_grant.rb
@@ -3,6 +3,13 @@ module Stormpath
     class IdSiteGrant < Stormpath::Resource::Base
       prop_accessor :grant_type, :token
 
+      def form_properties
+        {
+          grant_type: grant_type,
+          token: token
+        }
+      end
+
       def set_options(request)
         set_property :grant_type, request.grant_type
         set_property :token, request.token

--- a/lib/stormpath-sdk/oauth/password_grant.rb
+++ b/lib/stormpath-sdk/oauth/password_grant.rb
@@ -3,6 +3,14 @@ module Stormpath
     class PasswordGrant < Stormpath::Resource::Base
       prop_accessor :grant_type, :username, :password
 
+      def form_properties
+        {
+          grant_type: grant_type,
+          username: username,
+          password: password
+        }
+      end
+
       def set_options(request)
         set_property :username, request.username
         set_property :password, request.password

--- a/lib/stormpath-sdk/oauth/refresh_token.rb
+++ b/lib/stormpath-sdk/oauth/refresh_token.rb
@@ -3,6 +3,13 @@ module Stormpath
     class RefreshToken < Stormpath::Resource::Base
       prop_accessor :grant_type, :refresh_token
 
+      def form_properties
+        {
+          grant_type: grant_type,
+          refresh_token: refresh_token
+        }
+      end
+
       def set_options(request)
         set_property :refresh_token, request.refresh_token
         set_property :grant_type, request.grant_type

--- a/lib/stormpath-sdk/oauth/stormpath_token_grant.rb
+++ b/lib/stormpath-sdk/oauth/stormpath_token_grant.rb
@@ -1,7 +1,14 @@
 module Stormpath
   module Oauth
     class StormpathTokenGrant < Stormpath::Resource::Base
-      prop_accessor :grant_type, :refresh_token
+      prop_accessor :grant_type, :token
+
+      def form_properties
+        {
+          grant_type: grant_type,
+          token: token
+        }
+      end
 
       def set_options(request)
         set_property :token, request.token

--- a/spec/resource/application_spec.rb
+++ b/spec/resource/application_spec.rb
@@ -1082,6 +1082,31 @@ describe Stormpath::Resource::Application, :vcr do
       end
     end
 
+    context 'generate access token from client credentials request' do
+      let(:account_api_key) { account.api_keys.create({}) }
+
+      let(:client_credentials_grant_request) do
+        Stormpath::Oauth::ClientCredentialsGrantRequest.new(
+          account_api_key.id,
+          account_api_key.secret
+        )
+      end
+
+      let(:authenticate_oauth) { application.authenticate_oauth(client_credentials_grant_request) }
+
+      it 'should return access token response' do
+        expect(authenticate_oauth).to be_kind_of(Stormpath::Oauth::AccessTokenAuthenticationResult)
+      end
+
+      it 'response should contain token data' do
+        expect(authenticate_oauth.access_token).not_to be_empty
+        expect(authenticate_oauth.refresh_token).not_to be_empty
+        expect(authenticate_oauth.token_type).not_to be_empty
+        expect(authenticate_oauth.expires_in).not_to be_nil
+        expect(authenticate_oauth.stormpath_access_token_href).not_to be_empty
+      end
+    end
+
     context 'exchange id site token for access_token with invalid jwt' do
       let(:invalid_jwt_token) { 'invalid_token' }
 

--- a/stormpath-sdk.gemspec
+++ b/stormpath-sdk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency('multi_json', '>= 1.3.6')
   s.add_dependency('httpclient', '>= 2.2.5')
   s.add_dependency('uuidtools', '>= 2.1.3')
-  if RUBY_VERSION > '2.1'
+  if RUBY_VERSION < '2.2.2'
     s.add_dependency('activesupport', '>= 3.2.8', '< 5.0')
   else
     s.add_dependency('activesupport', '>= 3.2.8')

--- a/stormpath-sdk.gemspec
+++ b/stormpath-sdk.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |s|
   s.add_dependency('multi_json', '>= 1.3.6')
   s.add_dependency('httpclient', '>= 2.2.5')
   s.add_dependency('uuidtools', '>= 2.1.3')
-  s.add_dependency('activesupport', '>= 3.2.8')
+  if RUBY_VERSION > '2.1'
+    s.add_dependency('activesupport', '>= 3.2.8', '< 5.0')
+  else
+    s.add_dependency('activesupport', '>= 3.2.8')
+  end
   s.add_dependency('properties-ruby', "~> 0.0.4")
   s.add_dependency('http-cookie', "~> 1.0.2")
   s.add_dependency('java_properties')


### PR DESCRIPTION
This PR contains support for client credentials oauth.

Since we can't have 1-1 mappings of property names in a way that Ruby uses underscores and the Stormpath API camelcases, this contains an improvement for oauth form data passed to the server.

Also, Rails 5 just got out so this contains a fix for bundler requirements.

@ecrisostomo please review this.