### PR TITLE
Added 'Organization' as a valid type of account store

### DIFF
--- a/lib/stormpath-sdk/resource/account_store.rb
+++ b/lib/stormpath-sdk/resource/account_store.rb
@@ -22,6 +22,8 @@ class Stormpath::Resource::AccountStore < Stormpath::Resource::Instance
       Stormpath::Resource::Directory.new(*args)
     elsif /group/.match href
       Stormpath::Resource::Group.new(*args)
+    elsif /organizations/.match href
+      Stormpath::Resource::Organization.new(*args)
     else
       raise "inappropriate type of an account store"
     end 


### PR DESCRIPTION
When I tried to get an organization from an application account store I was getting the "inappropriate type of an account store" exception, now an organization is correctly mapped