### PR TITLE
Custom data query strings case in requests

### DIFF
--- a/lib/stormpath-sdk/http/request.rb
+++ b/lib/stormpath-sdk/http/request.rb
@@ -21,12 +21,11 @@ module Stormpath
       attr_accessor :http_method, :href, :query_string, :http_headers, :body, :api_key
 
       def initialize(http_method, href, query_string, http_headers, body, api_key)
-
         splitted = href.split '?'
 
         @query_string = query_string || {}
 
-        if splitted and splitted.length > 1
+        if splitted && splitted.length > 1
           @href = splitted[0]
           query_string_str = splitted[1]
           query_string_arr = query_string_str.split '&'
@@ -43,33 +42,36 @@ module Stormpath
         @body = body
         @api_key = api_key
 
-        if body
-          @http_headers.store 'Content-Length', @body.bytesize
-        end
-
+        @http_headers.store 'Content-Length', @body.bytesize if body
       end
 
       def resource_uri
         URI href
       end
 
-      def to_s_query_string canonical
+      def to_s_query_string(canonical)
         result = ''
 
         unless @query_string.empty?
-          Hash[@query_string.sort].each do |key, value|
-
+          Hash[@query_string.sort_by(&:to_s)].each do |key, value|
             enc_key = encode_url key, false, canonical
             enc_value = encode_url value, false, canonical
 
             result << '&' unless result.empty?
-            result << enc_key.camelize(:lower) << '='<< enc_value
+            result << camelize(enc_key) << '=' << enc_value
           end
         end
 
         result
       end
 
+      def camelize(key)
+        custom_data_params?(key) ? key : key.camelize(:lower)
+      end
+
+      def custom_data_params?(key)
+        key.starts_with?('customData.')
+      end
     end
   end
 end

--- a/spec/resource/collection_spec.rb
+++ b/spec/resource/collection_spec.rb
@@ -364,6 +364,44 @@ describe Stormpath::Resource::Collection, :vcr do
       end
     end
 
-  end
+    context 'search accounts by custom data' do
+      let(:directory) {test_api_client.directories.create name: random_directory_name }
 
+      let(:account) do
+        directory.accounts.create username: "jlpicard",
+           email: "capt@enterprise.com",
+           givenName: "Jean-Luc",
+           surname: "Picard",
+           password: "hakunaMatata179Enterprise"
+      end
+
+      let(:account2) do
+        directory.accounts.create username: "jlpicard2",
+           email: "capt2@enterprise.com",
+           givenName: "Jean-Luc2",
+           surname: "Picard2",
+           password: "hakunaMatata179Enterprise"
+      end
+
+      after do
+        directory.delete
+      end
+
+      it 'should search accounts by custom data attribute' do
+        account.custom_data['targetAttribute'] = 'findMe'
+        account2.custom_data['targetAttribute'] = 'findMe'
+        account.save
+        account2.save
+        expect(directory.accounts.search('customData.targetAttribute' => 'findMe').count).to eq(2)
+      end
+
+      it 'should be able to fetch custom data attributes with snake case' do
+        account.custom_data['target_attribute'] = 'findMe'
+        account2.custom_data['target_attribute'] = 'findMe'
+        account.save
+        account2.save
+        expect(directory.accounts.search('customData.target_attribute' => 'findMe').count).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/resource/collection_spec.rb
+++ b/spec/resource/collection_spec.rb
@@ -365,42 +365,60 @@ describe Stormpath::Resource::Collection, :vcr do
     end
 
     context 'search accounts by custom data' do
-      let(:directory) {test_api_client.directories.create name: random_directory_name }
+      let(:directory) { test_api_client.directories.create name: random_directory_name }
 
       let(:account) do
-        directory.accounts.create username: "jlpicard",
-           email: "capt@enterprise.com",
-           givenName: "Jean-Luc",
-           surname: "Picard",
-           password: "hakunaMatata179Enterprise"
+        directory.accounts.create(
+          username: 'jlpicard',
+          email: 'capt@enterprise.com',
+          givenName: 'Jean-Luc',
+          surname: 'Picard',
+          password: 'hakunaMatata179Enterprise'
+        )
       end
 
       let(:account2) do
-        directory.accounts.create username: "jlpicard2",
-           email: "capt2@enterprise.com",
-           givenName: "Jean-Luc2",
-           surname: "Picard2",
-           password: "hakunaMatata179Enterprise"
+        directory.accounts.create(
+          username: 'jlpicard2',
+          email: 'capt2@enterprise.com',
+          givenName: 'Jean-Luc2',
+          surname: 'Picard2',
+          password: 'hakunaMatata179Enterprise'
+        )
       end
 
       after do
         directory.delete
       end
 
-      it 'should search accounts by custom data attribute' do
-        account.custom_data['targetAttribute'] = 'findMe'
-        account2.custom_data['targetAttribute'] = 'findMe'
-        account.save
-        account2.save
-        expect(directory.accounts.search('customData.targetAttribute' => 'findMe').count).to eq(2)
+      context 'camelCase' do
+        before do
+          account.custom_data['targetAttribute'] = 'findMe'
+          account2.custom_data['targetAttribute'] = 'findMe'
+          account.save
+          account2.save
+        end
+
+        it 'should search accounts by custom data attribute' do
+          expect(account.custom_data['targetAttribute']).to eq 'findMe'
+          expect(directory.accounts.count).to eq 2
+          expect(directory.accounts.search('customData.targetAttribute' => 'findMe').count).to eq(2)
+        end
       end
 
-      it 'should be able to fetch custom data attributes with snake case' do
-        account.custom_data['target_attribute'] = 'findMe'
-        account2.custom_data['target_attribute'] = 'findMe'
-        account.save
-        account2.save
-        expect(directory.accounts.search('customData.target_attribute' => 'findMe').count).to eq(2)
+      context 'snake_case' do
+        before do
+          account.custom_data['target_attribute'] = 'findMe'
+          account2.custom_data['target_attribute'] = 'findMe'
+          account.save
+          account2.save
+        end
+
+        it 'should be able to fetch custom data attributes with snake case' do
+          expect(account.custom_data['target_attribute']).to eq 'findMe'
+          expect(directory.accounts.count).to eq 2
+          expect(directory.accounts.search('customData.target_attribute' => 'findMe').count).to eq(2)
+        end
       end
     end
   end

--- a/spec/resource/collection_spec.rb
+++ b/spec/resource/collection_spec.rb
@@ -402,6 +402,7 @@ describe Stormpath::Resource::Collection, :vcr do
         it 'should search accounts by custom data attribute' do
           expect(account.custom_data['targetAttribute']).to eq 'findMe'
           expect(directory.accounts.count).to eq 2
+          sleep 1
           expect(directory.accounts.search('customData.targetAttribute' => 'findMe').count).to eq(2)
         end
       end
@@ -417,6 +418,7 @@ describe Stormpath::Resource::Collection, :vcr do
         it 'should be able to fetch custom data attributes with snake case' do
           expect(account.custom_data['target_attribute']).to eq 'findMe'
           expect(directory.accounts.count).to eq 2
+          sleep 1
           expect(directory.accounts.search('customData.target_attribute' => 'findMe').count).to eq(2)
         end
       end


### PR DESCRIPTION
This pull request solves the bug for issue https://github.com/stormpath/stormpath-sdk-ruby/issues/163 with searching accounts depending on custom data columns.
The problem was that the SDK camelCased the custom data query strings too, which resulted in unexpected results in responses.

Please review.