### PR TITLE
Add alias method resend for resending verification emails to accounts

### DIFF
--- a/lib/stormpath-sdk/resource/application.rb
+++ b/lib/stormpath-sdk/resource/application.rb
@@ -29,7 +29,7 @@ class Stormpath::Resource::Application < Stormpath::Resource::Instance
   has_many :password_reset_tokens, can: [:get, :create]
   has_many :account_store_mappings, can: [:get, :create]
   has_many :groups, can: [:get, :create]
-  has_many :verification_emails, can: :create
+  has_many :verification_emails, can: [:create, :resend]
   has_many :api_keys
 
   has_one :default_account_store_mapping, class_name: :accountStoreMapping

--- a/lib/stormpath-sdk/resource/associations.rb
+++ b/lib/stormpath-sdk/resource/associations.rb
@@ -56,6 +56,7 @@ module Stormpath
                       end
                     data_store.create href, resource, item_class, options
                   end
+                  alias_method :resend, :create if can.include?(:resend)
                 end#can.include? :create
 
                 if can.include? :get

--- a/spec/resource/application_spec.rb
+++ b/spec/resource/application_spec.rb
@@ -552,6 +552,11 @@ describe Stormpath::Resource::Application, :vcr do
     it 'returns verification email' do
       expect(verification_emails).to be_kind_of Stormpath::Resource::VerificationEmail
     end
+
+    it 'resends verification email' do
+      expect(application.verification_emails.resend(login: account.email))
+        .to be_kind_of Stormpath::Resource::VerificationEmail
+    end
   end
 
   describe 'create_login_attempt' do


### PR DESCRIPTION
Currently, if this functionality is needed, a user has to call:

```ruby
application.verification_emails.create(login: account.email)
```
which gives the impression that a verification email is created, rather than resent.

This PR fixes issue https://github.com/stormpath/stormpath-sdk-ruby/issues/164 and implements an alias method `resend`

Please review