### PR TITLE
Implement http basic and bearer access token validation

### DIFF
--- a/lib/stormpath-sdk.rb
+++ b/lib/stormpath-sdk.rb
@@ -75,6 +75,8 @@ module Stormpath
     autoload :BasicLoginAttempt, 'stormpath-sdk/auth/basic_login_attempt'
     autoload :AuthenticationResult, 'stormpath-sdk/auth/authentication_result'
     autoload :BasicAuthenticator, 'stormpath-sdk/auth/basic_authenticator'
+    autoload :HttpBasicAuthentication, 'stormpath-sdk/auth/http_basic_authentication'
+    autoload :HttpBearerAuthentication, 'stormpath-sdk/auth/http_bearer_authentication'
   end
 
   module Provider

--- a/lib/stormpath-sdk/auth/http_basic_authentication.rb
+++ b/lib/stormpath-sdk/auth/http_basic_authentication.rb
@@ -1,0 +1,47 @@
+module Stormpath
+  module Authentication
+    class HttpBasicAuthentication
+      BASIC_PATTERN = /^Basic /
+      attr_reader :application, :authorization_header
+
+      def initialize(application, authorization_header)
+        @application = application
+        @authorization_header = authorization_header
+        raise Stormpath::Error if authorization_header.nil?
+      end
+
+      def authenticate!
+        raise Stormpath::Error if fetched_api_key.nil?
+        raise Stormpath::Error if fetched_api_key.secret != api_key_secret
+        fetched_api_key.account
+      end
+
+      private
+
+      def fetched_api_key
+        @fetched_api_key ||= application.api_keys.search(id: api_key_id).first
+      end
+
+      def api_key_id
+        decoded_authorization_header.first
+      end
+
+      def api_key_secret
+        decoded_authorization_header.last
+      end
+
+      def decoded_authorization_header
+        @decoded_authorization_header ||= begin
+          api_key_and_secret = Base64.decode64(basic_authorization_header).split(':')
+          raise Stormpath::Error if api_key_and_secret.count != 2
+          api_key_and_secret
+        end
+      end
+
+      def basic_authorization_header
+        raise Stormpath::Error unless authorization_header =~ BASIC_PATTERN
+        authorization_header.gsub(BASIC_PATTERN, '')
+      end
+    end
+  end
+end

--- a/lib/stormpath-sdk/auth/http_bearer_authentication.rb
+++ b/lib/stormpath-sdk/auth/http_bearer_authentication.rb
@@ -7,16 +7,14 @@ module Stormpath
       def initialize(application, authorization_header, options = {})
         @application = application
         @authorization_header = authorization_header
-        @local = options[:local]
+        @local = options[:local] || false
         raise Stormpath::Error if authorization_header.nil?
       end
 
       def authenticate!
-        if local
-          Stormpath::Oauth::LocalAccessTokenVerification.new(application, bearer_access_token).verify
-        else
-          Stormpath::Oauth::RemoteAccessTokenVerification.new(application, bearer_access_token).verify
-        end
+        Stormpath::Oauth::VerifyAccessToken.new(application, local: local)
+                                           .verify(bearer_access_token)
+                                           .account
       end
 
       private

--- a/lib/stormpath-sdk/auth/http_bearer_authentication.rb
+++ b/lib/stormpath-sdk/auth/http_bearer_authentication.rb
@@ -1,0 +1,30 @@
+module Stormpath
+  module Authentication
+    class HttpBearerAuthentication
+      BEARER_PATTERN = /^Bearer /
+      attr_reader :application, :authorization_header, :local
+
+      def initialize(application, authorization_header, options = {})
+        @application = application
+        @authorization_header = authorization_header
+        @local = options[:local]
+        raise Stormpath::Error if authorization_header.nil?
+      end
+
+      def authenticate!
+        if local
+          Stormpath::Oauth::LocalAccessTokenVerification.new(application, bearer_access_token).verify
+        else
+          Stormpath::Oauth::RemoteAccessTokenVerification.new(application, bearer_access_token).verify
+        end
+      end
+
+      private
+
+      def bearer_access_token
+        raise Stormpath::Error unless authorization_header =~ BEARER_PATTERN
+        authorization_header.gsub(BEARER_PATTERN, '')
+      end
+    end
+  end
+end

--- a/lib/stormpath-sdk/oauth/remote_access_token_verification.rb
+++ b/lib/stormpath-sdk/oauth/remote_access_token_verification.rb
@@ -16,8 +16,8 @@ module Stormpath
       end
 
       def validate_access_token
-        raise Stormpath::Oauth::Error, :jwt_invalid if decoded_jwt.second['stt'] != 'access'
-        raise Stormpath::Oauth::Error, :jwt_invalid if decoded_jwt.first['iss'] == application.href
+        raise Stormpath::Oauth::Error, :jwt_invalid unless decoded_jwt.second['stt'] == 'access'
+        raise Stormpath::Oauth::Error, :jwt_invalid unless decoded_jwt.first['iss'] == application.href
       end
 
       def decoded_jwt

--- a/spec/auth/http_basic_authentication_spec.rb
+++ b/spec/auth/http_basic_authentication_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe 'HttpBasicAuthentication', vcr: true do
+  let(:application) { test_api_client.applications.create(name: 'ruby sdk test app') }
+  let(:directory) { test_api_client.directories.create(name: random_directory_name) }
+  let(:account) do
+    application.accounts.create(
+      email: 'test@example.com',
+      given_name: 'Ruby SDK',
+      password: 'P@$$w0rd',
+      surname: 'SDK'
+    )
+  end
+  let(:api_key) { account.api_keys.create({}) }
+  let(:api_key_id) { api_key.id }
+  let(:api_key_secret) { api_key.secret }
+  let(:encoded_api_key) { Base64.encode64("#{api_key_id}:#{api_key_secret}") }
+  let(:basic_authorization_header) { "Basic #{encoded_api_key}" }
+  let(:authenticate) do
+    Stormpath::Authentication::HttpBasicAuthentication.new(application,
+                                                           basic_authorization_header).authenticate!
+  end
+
+  before do
+    test_api_client.account_store_mappings.create(application: application,
+                                                  account_store: directory,
+                                                  list_index: 1,
+                                                  is_default_account_store: true,
+                                                  is_default_group_store: true)
+  end
+
+  after do
+    account.delete
+    directory.delete
+    application.delete
+  end
+
+  describe 'with valid api key id and secret' do
+    it 'should return the associated account' do
+      expect(authenticate).to eq account
+    end
+  end
+
+  describe 'with invalid api key id and secret' do
+    let(:encoded_api_key) { Base64.encode64('bad_api_key_id:bad_api_key_secret') }
+
+    it 'should raise error' do
+      expect do
+        authenticate
+      end.to raise_error(Stormpath::Error)
+    end
+  end
+
+  describe 'with valid api key id and bad secret' do
+    let(:encoded_api_key) { Base64.encode64("#{api_key_id}:bad_api_key_secret") }
+
+    it 'should raise error' do
+      expect do
+        authenticate
+      end.to raise_error(Stormpath::Error)
+    end
+  end
+
+  describe 'with no basic authorization header provided' do
+    let(:basic_authorization_header) { nil }
+    it 'should raise error' do
+      expect do
+        authenticate
+      end.to raise_error(Stormpath::Error)
+    end
+  end
+
+  context 'with invalid authorization header type' do
+    let(:basic_authorization_header) { "Bearer #{encoded_api_key}" }
+
+    it 'should raise error' do
+      expect do
+        authenticate
+      end.to raise_error(Stormpath::Error)
+    end
+  end
+end

--- a/spec/auth/http_bearer_authentication_spec.rb
+++ b/spec/auth/http_bearer_authentication_spec.rb
@@ -44,22 +44,9 @@ describe 'HttpBearerAuthentication', vcr: true do
 
   describe 'remote authentication' do
     context 'with a valid bearer authorization header' do
-      it 'should return VerifyToken result' do
-        expect(authenticate_remotely).to be_kind_of(Stormpath::Oauth::VerifyToken)
-      end
-
-      it 'should contain account' do
-        expect(authenticate_remotely.account).to eq(account)
-      end
-    end
-
-    context 'with an invalid bearer authorization header' do
-      let(:bearer_authorization_header) { 'Bearer bad_access_token' }
-
-      it 'should raise error' do
-        expect do
-          authenticate_remotely
-        end.to raise_error(Stormpath::Error)
+      it 'should return account' do
+        expect(authenticate_remotely).to be_kind_of(Stormpath::Resource::Account)
+        expect(authenticate_remotely).to eq(account)
       end
     end
 
@@ -86,13 +73,9 @@ describe 'HttpBearerAuthentication', vcr: true do
 
   describe 'local authentication' do
     context 'with a valid bearer authorization header' do
-      it 'should return LocalAccessTokenVerificationResult' do
-        expect(authenticate_locally)
-          .to be_kind_of(Stormpath::Oauth::LocalAccessTokenVerificationResult)
-      end
-
-      it 'should be able to fetch account from result' do
-        expect(authenticate_locally.account).to eq(account)
+      it 'should return account' do
+        expect(authenticate_locally).to be_kind_of(Stormpath::Resource::Account)
+        expect(authenticate_locally).to eq(account)
       end
     end
   end

--- a/spec/auth/http_bearer_authentication_spec.rb
+++ b/spec/auth/http_bearer_authentication_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe 'HttpBearerAuthentication', vcr: true do
+  let(:application) { test_api_client.applications.create(name: 'ruby sdk test app') }
+  let(:directory) { test_api_client.directories.create(name: random_directory_name) }
+  let(:account) do
+    application.accounts.create(
+      email: 'test@example.com',
+      given_name: 'Ruby SDK',
+      password: 'P@$$w0rd',
+      surname: 'SDK'
+    )
+  end
+  let(:password_grant_request) do
+    Stormpath::Oauth::PasswordGrantRequest.new('test@example.com', 'P@$$w0rd')
+  end
+  let(:aquire_token) { application.authenticate_oauth(password_grant_request) }
+
+  let(:access_token) { aquire_token.access_token }
+  let(:bearer_authorization_header) { "Bearer #{access_token}" }
+  let(:authenticate_locally) do
+    Stormpath::Authentication::HttpBearerAuthentication.new(application,
+                                                            bearer_authorization_header,
+                                                            local: true).authenticate!
+  end
+  let(:authenticate_remotely) do
+    Stormpath::Authentication::HttpBearerAuthentication.new(application,
+                                                            bearer_authorization_header).authenticate!
+  end
+  before do
+    test_api_client.account_store_mappings.create(application: application,
+                                                  account_store: directory,
+                                                  list_index: 1,
+                                                  is_default_account_store: true,
+                                                  is_default_group_store: true)
+    account
+  end
+
+  after do
+    account.delete
+    directory.delete
+    application.delete
+  end
+
+  describe 'remote authentication' do
+    context 'with a valid bearer authorization header' do
+      it 'should return VerifyToken result' do
+        expect(authenticate_remotely).to be_kind_of(Stormpath::Oauth::VerifyToken)
+      end
+
+      it 'should contain account' do
+        expect(authenticate_remotely.account).to eq(account)
+      end
+    end
+
+    context 'with an invalid bearer authorization header' do
+      let(:bearer_authorization_header) { 'Bearer bad_access_token' }
+
+      it 'should raise error' do
+        expect do
+          authenticate_remotely
+        end.to raise_error(Stormpath::Error)
+      end
+    end
+
+    context 'with no bearer authorization header' do
+      let(:bearer_authorization_header) { nil }
+
+      it 'should raise error' do
+        expect do
+          authenticate_remotely
+        end.to raise_error(Stormpath::Error)
+      end
+    end
+
+    context 'with invalid authorization header type' do
+      let(:bearer_authorization_header) { "Basic #{access_token}" }
+
+      it 'should raise error' do
+        expect do
+          authenticate_remotely
+        end.to raise_error(Stormpath::Error)
+      end
+    end
+  end
+
+  describe 'local authentication' do
+    context 'with a valid bearer authorization header' do
+      it 'should return LocalAccessTokenVerificationResult' do
+        expect(authenticate_locally)
+          .to be_kind_of(Stormpath::Oauth::LocalAccessTokenVerificationResult)
+      end
+
+      it 'should be able to fetch account from result' do
+        expect(authenticate_locally.account).to eq(account)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implementation for issue https://github.com/stormpath/stormpath-sdk-ruby/issues/166
Since the _Bearer access token validation_ workflow is basically stripping off the `Bearer`part of the string of the authorization header and passing the leftover (`access_token`) for verification (local or remote) I reused the refactored ``Stormpath::Oauth::VerifyAccessToken`` class from the `mc-local-token-validation-165` branch.

After reviewing, please merge into [mc-local-token-validation-165](https://github.com/stormpath/stormpath-sdk-ruby/pull/173).